### PR TITLE
chore: prevent renovate from updating to dotnet previews

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
   "[csharp]": {
     "editor.codeActionsOnSave": {
-      "source.addMissingImports": true,
-      "source.fixAll": true,
-      "source.organizeImports": true
+      "source.addMissingImports": "explicit",
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
     },
     "editor.formatOnPaste": true,
     "editor.formatOnSave": true,

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.3.24204.13",
+    "version": "8.0.100",
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,12 @@
     },
     {
       "matchPackagePrefixes": [
+        "dotnet-sdk"
+      ],
+      "allowedVersions": "!/preview/"
+    },
+    {
+      "matchPackagePrefixes": [
         "GodotSharp",
         "Godot.NET.Sdk"
       ],


### PR DESCRIPTION
Makes renovate changes to hopefully prevent renovate from updating us to preview .NET versions. See https://github.com/chickensoft-games/GodotPackage/pull/95 