### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,33 +1,33 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":semanticCommits"
   ],
   "prHourlyLimit": 2,
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "*"
-      ],
       "groupName": "all dependencies",
       "groupSlug": "all-deps",
-      "automerge": true
-    },
-    {
-      "matchPackagePrefixes": [
-        "dotnet-sdk"
+      "automerge": true,
+      "matchPackageNames": [
+        "*"
       ]
     },
     {
-      "matchPackagePrefixes": [
-        "GodotSharp",
-        "Godot.NET.Sdk"
+      "matchPackageNames": [
+        "dotnet-sdk{/,}**"
       ]
     },
     {
-      "matchPackagePrefixes": [
-        "Chickensoft"
+      "matchPackageNames": [
+        "GodotSharp{/,}**",
+        "Godot.NET.Sdk{/,}**"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "Chickensoft{/,}**"
       ],
       "allowedVersions": "/^(\\d+\\.\\d+\\.\\d+)(-godot(\\d+\\.)+\\d+(-.*)?)?$/"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     ":semanticCommits"
   ],
   "prHourlyLimit": 2,
-  "versioning": "loose",
   "packageRules": [
     {
       "matchPackagePatterns": [
@@ -18,15 +17,13 @@
     {
       "matchPackagePrefixes": [
         "dotnet-sdk"
-      ],
-      "allowedVersions": "!/preview/"
+      ]
     },
     {
       "matchPackagePrefixes": [
         "GodotSharp",
         "Godot.NET.Sdk"
-      ],
-      "allowedVersions": "/^(\\d+\\.\\d+\\.\\d+)(-(beta|rc)\\.(\\d+)(\\.\\d+)*)?$/"
+      ]
     },
     {
       "matchPackagePrefixes": [


### PR DESCRIPTION
* Removed renovate config rule versioning=loose, to prevent updates to preview versions of dependencies.
* Removed handwritten rules for avoiding preview versions on individual dependencies (unnecessary when not using versioning=loose versioning globally).
* Implemented migrations of renovate config suggested by renovate debug output:
  * Extend the "recommended" config instead of the "base" config
  * Use "matchPackageNames" instead of "matchPackagePatterns"
  * Use "matchPackageNames" with patterns instead of "matchPackagePrefixes"