### PR TITLE
chore: update VSCode import-organization setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -141,7 +141,6 @@
   "omnisharp.enableMsBuildLoadProjectsOnDemand": false,
   "omnisharp.enableRoslynAnalyzers": true,
   "omnisharp.maxFindSymbolsItems": 3000,
-  "omnisharp.organizeImportsOnFormat": true,
   "omnisharp.useModernNet": true,
   // Remove these if you're happy with your terminal profiles.
   "terminal.integrated.defaultProfile.windows": "Git Bash",
@@ -162,5 +161,6 @@
       "source": "PowerShell"
     }
   },
-  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true
+  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+  "dotnet.formatting.organizeImportsOnFormat": true
 }


### PR DESCRIPTION
Changed the name of the C# extension's setting for organizing imports to reflect updates.