### PR TITLE
chore: don't run release action on forks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
   release:
     name: '📦 Release'
     runs-on: ubuntu-latest
+    if: github.repository == 'chickensoft-games/GoDotTest'
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_NOLOGO: true


### PR DESCRIPTION
Updates the release workflow to require that it is executed in the original Chickensoft repository, to prevent failed release runs in forks. (See chickensoft-games/GameTools#33.)